### PR TITLE
Adding Copilot custom instructions for each template

### DIFF
--- a/data-science-template/.github/copilot-instructions.md
+++ b/data-science-template/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+For more information on the project, see README.md. 
+
+## Code layout 
+Use spaces, not tabs. 4 spaces per indentation level. 
+
+Limit all lines to a maximum of 79 characters.
+
+Surround top-level function and class definitions with two blank lines.
+
+For code layout specifications not mentioned here, adhere to PEP8.  
+
+## Naming Conventions
+Use snake_case for variable, function, and file names. 
+Use PascalCase class class names. 
+Use all uppercase with underscores separating words for constants.
+Use whole words in names when possible
+
+Use meaningful variable and function names that reflect their purpose.
+
+## Comments
+When there are comments for modules, classes, and functions use docstrings. 
+
+## Tests
+Write tests for any new calculations using pytest.

--- a/data-science-template/.vscode/settings.json
+++ b/data-science-template/.vscode/settings.json
@@ -3,5 +3,7 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+
 }

--- a/django-template/.github/copilot-instructions.md
+++ b/django-template/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+This project provides a template for starting a new Django application with best practices and common configurations.
+
+For more information on the project, see README.md. 
+
+## Code layout 
+Use spaces, not tabs. 4 spaces per indentation level. 
+
+Limit all lines to a maximum of 79 characters.
+
+Surround top-level function and class definitions with two blank lines.
+
+For code layout specifications not mentioned here, adhere to PEP8.  
+
+## Naming Conventions
+Use snake_case for variable, function, and file names. 
+Use PascalCase class class names. 
+Use all uppercase with underscores separating words for constants.
+Use whole words in names when possible
+
+Use meaningful variable and function names that reflect their purpose.
+
+## Comments
+When there are comments for modules, classes, and functions use docstrings. 
+
+## Tests
+Write unit tests for models, views, and forms using Django's built in unittest framework.
+
+## Django instructions 
+Avoid business logic in views; delegate complex logic to helper functions or services.
+
+Use descriptive and human-readable URLs.
+
+Follow a consistent folder structure for templates (e.g., app_name/templates/app_name/...).

--- a/django-template/.vscode/settings.json
+++ b/django-template/.vscode/settings.json
@@ -8,5 +8,7 @@
         "./hello",
         "-p",
         "test*.py"
-    ]
+    ],
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+
 }

--- a/fastapi-template/.github/copilot-instructions.md
+++ b/fastapi-template/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+This project provides a template for starting a new Fast API application with best practices and common configurations.
+
+For more information on the project, see README.md. 
+
+## Code layout 
+Use spaces, not tabs. 4 spaces per indentation level. 
+
+Limit all lines to a maximum of 79 characters.
+
+Surround top-level function and class definitions with two blank lines.
+
+For code layout specifications not mentioned here, adhere to PEP8.  
+
+## Naming Conventions
+Use snake_case for variable, function, and file names. 
+Use PascalCase class class names. 
+Use all uppercase with underscores separating words for constants.
+Use whole words in names when possible
+
+Use meaningful variable and function names that reflect their purpose.
+
+## Comments
+When there are comments for modules, classes, and functions use docstrings. 
+
+## Tests
+Write tests for models, views, and forms using pytest.
+
+## Fast API instructions 
+Always define types for your request parameters, responses, and data models.
+
+Use async functions for routes and database operations.
+
+Use Pydantic models for data validation and serialization.

--- a/fastapi-template/.vscode/settings.json
+++ b/fastapi-template/.vscode/settings.json
@@ -3,5 +3,7 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+
 }

--- a/flask-template/.github/copilot-instructions.md
+++ b/flask-template/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+This project provides a template for starting a new Flask application with best practices and common configurations.
+
+For more information on the project, see README.md. 
+
+## Code layout 
+Use spaces, not tabs. 4 spaces per indentation level. 
+
+Limit all lines to a maximum of 79 characters.
+
+Surround top-level function and class definitions with two blank lines.
+
+For code layout specifications not mentioned here, adhere to PEP8.  
+
+## Naming Conventions
+Use snake_case for variable, function, and file names. 
+Use PascalCase class class names. 
+Use all uppercase with underscores separating words for constants.
+Use whole words in names when possible
+
+Use meaningful variable and function names that reflect their purpose.
+
+## Comments
+When there are comments for modules, classes, and functions use docstrings. 
+
+## Tests
+Write tests for models, views, and forms using pytest.

--- a/flask-template/.vscode/settings.json
+++ b/flask-template/.vscode/settings.json
@@ -4,5 +4,7 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+
 }

--- a/package-template/.github/copilot-instructions.md
+++ b/package-template/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+This project provides a template for starting a new Flask application with best practices and common configurations.
+
+For more information on the project, see README.md. 
+
+## Code layout 
+Use spaces, not tabs. 4 spaces per indentation level. 
+
+Limit all lines to a maximum of 79 characters.
+
+Surround top-level function and class definitions with two blank lines.
+
+Specify dependencies in pyproject.toml and developer requirements in dev-requirements.txt. 
+
+For code layout specifications not mentioned here, adhere to PEP8.  
+
+## Naming Conventions
+Use snake_case for variable, function, and file names. 
+Use PascalCase class class names. 
+Use all uppercase with underscores separating words for constants.
+Use whole words in names when possible
+
+Use meaningful variable and function names that reflect their purpose.
+
+## Comments
+When there are comments for modules, classes, and functions use docstrings. 
+
+## Tests
+Write tests for models, views, and forms using pytest.

--- a/package-template/.vscode/settings.json
+++ b/package-template/.vscode/settings.json
@@ -3,5 +3,7 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+
 }

--- a/script-template/.github/copilot-instructions.md
+++ b/script-template/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+For more information on the project, see README.md. 
+
+## Code layout 
+Use spaces, not tabs. 4 spaces per indentation level. 
+
+Limit all lines to a maximum of 79 characters.
+
+Surround top-level function and class definitions with two blank lines.
+
+For code layout specifications not mentioned here, adhere to PEP8.  
+
+## Naming Conventions
+Use snake_case for variable, function, and file names. 
+Use PascalCase class class names. 
+Use all uppercase with underscores separating words for constants.
+Use whole words in names when possible
+
+Use meaningful variable and function names that reflect their purpose.
+
+## Comments
+When there are comments for modules, classes, and functions use docstrings. 
+
+## Tests
+Write tests for new classes or functions using pytest.

--- a/script-template/.vscode/settings.json
+++ b/script-template/.vscode/settings.json
@@ -3,5 +3,7 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+
 }


### PR DESCRIPTION
Experimenting with custom instructions and reusable prompts for templates repo

- Updating each template `settings.json` to include custom instructions 
- Add `.github` folder to each template
- Add `copilot-instructions.md` for each template 